### PR TITLE
fix: prevent unwraping unset values

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -478,32 +478,28 @@ where
     }
 
     fn update_weather_data(&self) -> Command<Message> {
-        let coords = (
-            self.config
-                .latitude
-                .as_ref()
-                .unwrap()
-                .parse::<f64>()
-                .expect("Error parsing string to f64"),
-            self.config
-                .longitude
-                .as_ref()
-                .unwrap()
-                .parse::<f64>()
-                .expect("Error parsing string to f64"),
-        );
+        if let (Some(lat), Some(long)) = (
+            self.config.latitude.as_ref(),
+            self.config.longitude.as_ref(),
+        ) {
+            let coords = (
+                lat.parse::<f64>().expect("Error parsing string to f64"),
+                long.parse::<f64>().expect("Error parsing string to f64"),
+            );
 
-        Command::perform(WeatherData::get_weather_data(coords), |data| match data {
-            Ok(data) => {
-                let Some(data) = data else {
-                    return cosmic::app::Message::App(Message::Error(
-                        "Could not get weather data.".to_string(),
-                    ));
-                };
-                cosmic::app::Message::App(Message::SetWeatherData(data.clone()))
-            }
-            Err(err) => cosmic::app::Message::App(Message::Error(err.to_string())),
-        })
+            return Command::perform(WeatherData::get_weather_data(coords), |data| match data {
+                Ok(data) => {
+                    let Some(data) = data else {
+                        return cosmic::app::Message::App(Message::Error(
+                            "Could not get weather data.".to_string(),
+                        ));
+                    };
+                    cosmic::app::Message::App(Message::SetWeatherData(data.clone()))
+                }
+                Err(err) => cosmic::app::Message::App(Message::Error(err.to_string())),
+            });
+        };
+        Command::none()
     }
 
     fn about(&self) -> Element<Message> {


### PR DESCRIPTION
When config is not set, so for example first launch of the app, the update method trying to unwrap unset values, so it's panicing. This will prevent it.